### PR TITLE
Set .docker script line endings to lf

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,8 @@
-*.css   text    eol=lf
-*.html  text    eol=lf
-*.js    text    eol=lf
-*.json  text    eol=lf
-*.py    text    eol=lf
-*.md    text    eol=lf
-*.txt   text    eol=lf
+*.css     text    eol=lf
+*.html    text    eol=lf
+*.js      text    eol=lf
+*.json    text    eol=lf
+*.py      text    eol=lf
+*.md      text    eol=lf
+*.txt     text    eol=lf
+.docker/* text    eol=lf


### PR DESCRIPTION
When running `docker-compose up -d` on Windows, I was running into the following error:
```
standard_init_linux.go:211: exec user process caused "no such file or directory"
```
This is caused by the scripts in `.docker` getting checked out with CRLF line endings by default. This PR updates `.gitattributes` to include those scripts.