### PR TITLE
Update autocomplete function to a general search function

### DIFF
--- a/racetime/urls.py
+++ b/racetime/urls.py
@@ -31,13 +31,10 @@ urlpatterns = [
         path('userinfo', views.OAuthUserInfo.as_view(), name='oauth2_userinfo'),
     ])),
 
-    path('autocomplete/', include([
-        path('user', views.AutocompleteUser.as_view(), name='autocomplete_user'),
-    ])),
-
     path('', views.Home.as_view(), name='home'),
     path('request_category', views.RequestCategory.as_view(), name='request_category'),
     path('races/data', views.RaceListData.as_view(), name='race_list_data'),
+    path('user/search', views.AutocompleteUser.as_view(), name='autocomplete_user'),
     path('user/<str:user>', views.ViewProfile.as_view(), name='view_profile'),
     path('user/<str:user>/', include([
         path('data', views.UserProfileData.as_view(), name='user_profile_data'),


### PR DESCRIPTION
* Switches autocomplete to a more relevant api endpoint /user/search?
* Removes ability to search for null values responding with the whole DB
* Adds ability to search by just name, discriminator or name+discriminator

It has some somewhat duplicated things in it as term works for all responses but giving the options to specifically search for options of just name or just scrim is useful.