### PR TITLE
Update view to enable support for category

### DIFF
--- a/racetime/models/category.py
+++ b/racetime/models/category.py
@@ -173,6 +173,16 @@ class Category(models.Model):
         This is used when another models' data dict needs to include category
         data, e.g. race data showing which category the race is in.
         """
+        goals = Goal.objects.filter(
+            category=self,
+            active=True,
+        )
+        category_goals = []
+        for goal in goals:
+            category_goals.append({
+                'name': goal.name,
+                'total_races': goal.total_races
+                })
         return {
             'name': self.name,
             'short_name': self.short_name,
@@ -180,6 +190,7 @@ class Category(models.Model):
             'url': self.get_absolute_url(),
             'data_url': self.get_data_url(),
             'image': self.image.url if self.image else None,
+            'goals': category_goals,
         }
 
     def can_edit(self, user):


### PR DESCRIPTION
While category was missing as a flag, I think we don't need to add in finish_time and user info as its own for just the requested user. If they want the rest of that I think it would be best if they pass show_entrants to get that and parse from that.
Willing to be moved on that.

For the userdata, do you have an efficent way to pull the number of times a user has raced a goal/personal time per the issue?
As is I've appended goals to the category response in general as it seems like useful information.