### PR TITLE
Reduce DOM updates from the timer

### DIFF
--- a/racetime/static/racetime/script/base.js
+++ b/racetime/static/racetime/script/base.js
@@ -35,13 +35,19 @@ $(function() {
         timer -= secs * 1000;
         var ds = (timer - (timer % 100)) / 100;
 
-        $(this).html(
+        var currentTimerHtml =
             (negative ? '-' : '')
             + hours
             + ':' + ('00' + mins).slice(-2)
             + ':' + ('00' + secs).slice(-2)
-            + '<small>.' + ('' + ds) + '</small>'
-        );
+            + '<small>.' + ('' + ds) + '</small>';
+
+        var displayedTime = $(this).attr('displayed-time');
+
+        if (currentTimerHtml != displayedTime) {
+            $(this).html(currentTimerHtml);
+            $(this).attr('displayed-time', currentTimerHtml);
+        }
     };
     var autotick = function() {
         $('time.autotick').each(updateTimer);


### PR DESCRIPTION
Modified updateTimer to store the the html last used to update the timer
as an attribute on the element; this is used to only call $.html when
the html actually changes.

On my dev machine, this reduced CPU usage for the Firefox Web Content
process from 47% to 9%.