### PR TITLE
Add split command for LiveSplit comparisons

### DIFF
--- a/racetime/consumers.py
+++ b/racetime/consumers.py
@@ -179,6 +179,9 @@ class RaceConsumer(AsyncWebsocketConsumer):
         await self.deliver('race.data', race=event['race'], version=event['version'])
         await self.deliver('race.renders', renders=event['renders'], version=event['version'])
 
+    async def race_split(self, event):
+        await self.deliver(event['type'], split=event['split'])
+
     async def send_race(self):
         """
         Send pre-loaded race data (assuming we have it).

--- a/racetime/models/race.py
+++ b/racetime/models/race.py
@@ -1969,7 +1969,7 @@ class Entrant(models.Model):
             'split_time': split_time,
             'is_undo': split_time == '-',
             'is_finish': is_finish,
-            'username': str(self.user)
+            'user_id': self.user.hashid,
         }
 
         self.race.broadcast_split(split)

--- a/racetime/models/race.py
+++ b/racetime/models/race.py
@@ -1969,7 +1969,7 @@ class Entrant(models.Model):
             'split_time': split_time,
             'is_undo': split_time == '-',
             'is_finish': is_finish,
-            'username': self.user.name
+            'username': str(self.user)
         }
 
         self.race.broadcast_split(split)

--- a/racetime/models/race.py
+++ b/racetime/models/race.py
@@ -1963,12 +1963,12 @@ class Entrant(models.Model):
         else:
             raise SafeException('Possible sync error. Refresh to continue.')
 
-    def update_split(self, split_name, split_time):
+    def update_split(self, split_name, split_time, is_finish):
         split = {
             'split_name': split_name,
             'split_time': split_time,
             'is_undo': split_time == '-',
-            'is_finish': split_name == '__FINISH__',
+            'is_finish': is_finish,
             'username': self.user.name
         }
 

--- a/racetime/race_actions.py
+++ b/racetime/race_actions.py
@@ -142,7 +142,7 @@ class Undone:
     def action(self, race, user, data):
         entrant = race.in_race(user)
         if entrant:
-            entrant.update_split('__FINISH__', '-')
+            entrant.update_split('', '-', True)
             entrant.undone()
         else:
             raise SafeException('Possible sync error. Refresh to continue.')
@@ -157,7 +157,7 @@ class Split:
             split_name = data.get('split', '')
             if not split_name:
                 raise SafeException('Split name must not be empty')
-            entrant.update_split(split_name, data['time'])
+            entrant.update_split(split_name, data.get('time', '-'), data.get('is_finish', False))
         else:
             raise SafeException('Possible sync error. Refresh to contniue.')
 
@@ -204,7 +204,7 @@ class UndoneOrUnforfeit:
     def action(self, race, user, data):
         entrant = race.in_race(user)
         if entrant and entrant.finish_time:
-            entrant.update_split('__FINISH__', '-')
+            entrant.update_split('', '-', True)
             entrant.undone()
         elif entrant and entrant.dnf:
             entrant.unforfeit()

--- a/racetime/race_actions.py
+++ b/racetime/race_actions.py
@@ -142,9 +142,24 @@ class Undone:
     def action(self, race, user, data):
         entrant = race.in_race(user)
         if entrant:
+            entrant.update_split('__FINISH__', '-')
             entrant.undone()
         else:
             raise SafeException('Possible sync error. Refresh to continue.')
+
+
+class Split:
+    commands = ['split']
+
+    def action(self, race, user, data):
+        entrant = race.in_race(user)
+        if entrant:
+            split_name = data.get('split', '')
+            if not split_name:
+                raise SafeException('Split name must not be empty')
+            entrant.update_split(split_name, data['time'])
+        else:
+            raise SafeException('Possible sync error. Refresh to contniue.')
 
 
 class Forfeit:
@@ -189,6 +204,7 @@ class UndoneOrUnforfeit:
     def action(self, race, user, data):
         entrant = race.in_race(user)
         if entrant and entrant.finish_time:
+            entrant.update_split('__FINISH__', '-')
             entrant.undone()
         elif entrant and entrant.dnf:
             entrant.unforfeit()
@@ -306,6 +322,7 @@ commands = {
         Unready,
         Done,
         Undone,
+        Split,
         Forfeit,
         Unforfeit,
         LeaveOrForfeit,

--- a/racetime/urls.py
+++ b/racetime/urls.py
@@ -128,6 +128,7 @@ urlpatterns = [
         path('unready', views.Unready.as_view(), name='unready'),
         path('done', views.Done.as_view(), name='done'),
         path('undone', views.Undone.as_view(), name='undone'),
+        path('split', views.Split.as_view(), name='split'),
         path('forfeit', views.Forfeit.as_view(), name='forfeit'),
         path('unforfeit', views.Unforfeit.as_view(), name='unforfeit'),
         path('add_comment', views.AddComment.as_view(), name='add_comment'),

--- a/racetime/views/__init__.py
+++ b/racetime/views/__init__.py
@@ -82,6 +82,7 @@ from .race_actions import (
     RequestInvite,
     SetTeam,
     Undone,
+    Split,
     Unforfeit,
     Unready,
 )
@@ -211,6 +212,7 @@ __all__ = [
     'Forfeit',
     'Join',
     'Leave',
+    'Split',
     'Message',
     'Ready',
     'RequestInvite',

--- a/racetime/views/race_actions.py
+++ b/racetime/views/race_actions.py
@@ -56,6 +56,10 @@ class Undone(race_actions.Undone, RaceAction):
     pass
 
 
+class Split(race_actions.Split, RaceAction):
+    pass
+
+
 class Forfeit(race_actions.Forfeit, RaceAction):
     pass
 


### PR DESCRIPTION
Initial implementation of adding comparison capabilities. 

Upon splitting in LiveSplit, a "race.split" action will be called with a string of the split time. On undoing splits, the time will be "-", which will be interpreted on the LiveSplit side. The split data is then broadcasted to all the racers through the race socket.

In order for the split comparison to be generated, the split names have to be matching on both of the racer's side, which matches the SRL implementation.

PR for LiveSplit component: https://github.com/LiveSplit/LiveSplit.Racetime/pull/8