### PR TITLE
More detailed error messages for sync errors

### DIFF
--- a/racetime/utils.py
+++ b/racetime/utils.py
@@ -389,6 +389,12 @@ class SafeException(Exception):
     """
     pass
 
+class SyncError(SafeException):
+    """
+    Used to indicate an exception caused by a state mismatch between the user and the server.
+    """
+    pass
+
 
 def chunkify(items, size=100):
     """


### PR DESCRIPTION
This adds more detailed error messages for the different situations in which the message “Possible sync error. Refresh to continue.” would be used previously, which should help bot developers with debugging these errors.

The code that replaces these errors with something more useful for dot commands now checks for a new subclass of `SafeException` instead of checking the exception message. (This also fixes a bug where one of them said “contniue” instead of “continue” and thus wasn't caught by that check.)

I've split some of the errors into two where two distinct conditions were being checked, but left checks of more than two conditions alone. I don't think the exact wording of these messages is too important since regular users should normally not see them, but I've kept the “Refresh to continue.” part in each of them just in case.