### PR TITLE
Pre-fill create race form from GET parameters

### DIFF
--- a/racetime/views/race.py
+++ b/racetime/views/race.py
@@ -431,6 +431,11 @@ class RaceFormMixin(RaceMixin, UserMixin):
         kwargs = super().get_form_kwargs()
         kwargs['category'] = self.get_category()
         kwargs['can_moderate'] = kwargs['category'].can_moderate(self.user)
+        for field in models.Race._meta.get_fields():
+            if field.name in self.request.GET:
+                kwargs['initial'][field.name] = self.request.GET[field.name]
+                if field.name == 'custom_goal':
+                    kwargs['initial']['goal'] = ''
         return kwargs
 
 

--- a/racetime/views/race.py
+++ b/racetime/views/race.py
@@ -431,11 +431,6 @@ class RaceFormMixin(RaceMixin, UserMixin):
         kwargs = super().get_form_kwargs()
         kwargs['category'] = self.get_category()
         kwargs['can_moderate'] = kwargs['category'].can_moderate(self.user)
-        for field in models.Race._meta.get_fields():
-            if field.name in self.request.GET:
-                kwargs['initial'][field.name] = self.request.GET[field.name]
-                if field.name == 'custom_goal':
-                    kwargs['initial']['goal'] = ''
         return kwargs
 
 
@@ -488,6 +483,15 @@ class CreateRace(UserPassesTestMixin, BaseCreateRace):
         self.user.log_action('race_create', self.request)
 
         return http.HttpResponseRedirect(race.get_absolute_url())
+
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        for field in self.get_form_class()._meta.fields:
+            if field in self.request.GET:
+                kwargs['initial'][field] = self.request.GET[field]
+                if field == 'custom_goal':
+                    kwargs['initial']['goal'] = ''
+        return kwargs
 
     def test_func(self):
         if not self.user.is_authenticated:


### PR DESCRIPTION
This allows links to be built which present the user with a pre-filled “start race” form. For example, I would be able to put a link on a [Mido's House](https://github.com/midoshouse/midos.house) event page for opening a practice room with the appropriate goal name and room settings.