### PR TITLE
Limit size of survey select boxes

### DIFF
--- a/racetime/static/racetime/style/race.css
+++ b/racetime/static/racetime/style/race.css
@@ -337,6 +337,10 @@ main {
 .race-chat > .messages > .bot-survey input {
     border-color: #a0ace8;
 }
+.race-chat > .messages > .bot-survey select {
+    max-width: 284px;
+    max-width: calc(100% - 20px);
+}
 .race-chat > .messages.pinned > .bot-survey::before {
     content: none;
 }


### PR DESCRIPTION
This ensures select boxes with long option labels don't stick out of the chat layout.

I noticed this can happen in the course of developing [ootr-randobot#17](https://github.com/deains/ootr-randobot/pull/17) and decided to PR a small fix here.

* Sets a fallback value for browsers that don't understand calc()
* In calc()-capable browsers, allows for select boxes to get wider if the container gets wider (e.g. in popped-out chat)