### PR TITLE
Avoid pinned messages completely covering regular messages

### DIFF
--- a/racetime/static/racetime/style/race.css
+++ b/racetime/static/racetime/style/race.css
@@ -208,6 +208,8 @@ main {
 .race-chat > .messages.pinned {
     box-shadow: 0 6px 3px -3px #212328;
     margin: 8px 0 0;
+    max-height: 50%;
+    overflow-y: auto;
     position: relative;
 }
 .race-chat > .messages.regular {


### PR DESCRIPTION
There was a bug causing Mido to crash several times in the past couple hours, which caused him to post many pinned messages to <https://racetime.gg/ootr/epic-mamamu-9807>. The pinned messages completely cover the regular messages on my screen with a logical resolution of 1080p, making the regular messages unreadable. This PR fixes that by limiting the height of the pinned messages to 50%, with scrolling overflow.

On the Mido's House side, the crash is now fixed and I'm working on an additional fix to prevent Mido from posting duplicate pins after restarting.