### PR TITLE
Change sorting to move inactive leaderboards behind active ones

### DIFF
--- a/racetime/views/category.py
+++ b/racetime/views/category.py
@@ -195,7 +195,7 @@ class CategoryLeaderboards(Category):
             show_leaderboard=True,
         )
         goals = goals.annotate(num_races=db_models.Count('race__id'))
-        goals = goals.order_by('-num_races', 'name')
+        goals = goals.order_by('-active', '-num_races', 'name')
         for goal in goals:
             rankings = models.UserRanking.objects.filter(
                 category=category,


### PR DESCRIPTION
This change will move inactive leaderboards to the end of the leaderboards list.

Sorting will first be by active state, then by number of races, and finally by name.