### PR TITLE
Add optional devcontainer for local development

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,22 @@
+FROM mcr.microsoft.com/devcontainers/python:1-3.12-bookworm
+
+ENV PYTHONUNBUFFERED=1
+
+# Install Node.js 24 LTS
+RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
+    && apt-get install -y nodejs
+
+# Install MySQL client libraries and build tools needed for mysqlclient package
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends \
+    default-libmysqlclient-dev \
+    pkg-config \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy wait-for-it and start scripts for WAITFOR environment variable support
+COPY .docker /.docker
+RUN chmod +x /.docker/wait-for-it.sh /.docker/start
+
+# Note: Python dependencies will be installed after container creation via postCreateCommand
+# because requirements.txt contains "-e ." which requires the project code to be mounted

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,58 @@
+// For format details, see https://containers.dev/implementors/json_reference/. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/postgres
+{
+    "name": "Python 3.12 & MySQL",
+    "dockerComposeFile": "docker-compose.yml",
+    "service": "app",
+    "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+    "forwardPorts": [
+        8000, // Django
+        3306, // MySQL
+        6379 // Redis
+    ],
+    // Use 'postCreateCommand' to run commands after the container is created.
+    "postCreateCommand": "bash .devcontainer/post-create.sh",
+    // Use 'postStartCommand' to run commands each time the container starts
+    "postStartCommand": "bash .devcontainer/post-start.sh",
+    // Configure tool-specific properties.
+    "customizations": {
+        // JetBrains IDEs ignore vscode specific settings.
+        "vscode": {
+            "extensions": [
+                "ms-python.python",
+                "ms-python.vscode-pylance",
+                "ms-python.debugpy",
+                "batisteo.vscode-django",
+                "mtxr.sqltools",
+                "mtxr.sqltools-driver-mysql",
+                "eamodio.gitlens",
+                "mhutchie.git-graph",
+                "editorconfig.editorconfig",
+                "dbaeumer.vscode-eslint",
+                "esbenp.prettier-vscode"
+            ],
+            "settings": {
+                "python.defaultInterpreterPath": "/usr/local/bin/python",
+                "python.linting.enabled": true,
+                "python.linting.pylintEnabled": false,
+                "python.formatting.provider": "black",
+                "python.testing.pytestEnabled": true,
+                "python.testing.unittestEnabled": false,
+                "editor.formatOnSave": true,
+                "files.trimTrailingWhitespace": true,
+                "files.insertFinalNewline": true,
+                "[python]": {
+                    "editor.defaultFormatter": "ms-python.python",
+                    "editor.tabSize": 4
+                },
+                "[javascript]": {
+                    "editor.defaultFormatter": "esbenp.prettier-vscode",
+                    "editor.tabSize": 2
+                },
+                "[json]": {
+                    "editor.defaultFormatter": "esbenp.prettier-vscode"
+                }
+            }
+        }
+    }
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,45 @@
+version: '3.8'
+
+services:
+  app:
+    build:
+      context: ..
+      dockerfile: .devcontainer/Dockerfile
+    volumes:
+      - ..:/workspaces/racetime-app:cached
+    command: sleep infinity
+    depends_on:
+      - db
+      - redis
+    networks:
+      - racetime-network
+
+  db:
+    image: mariadb
+    restart: unless-stopped
+    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
+    volumes:
+      - mysql-data:/var/lib/mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: racetime
+      MYSQL_DATABASE: racetime
+      MYSQL_USER: racetime
+      MYSQL_PASSWORD: racetime
+    networks:
+      racetime-network:
+        aliases:
+          - racetime.db
+
+  redis:
+    image: redis
+    restart: unless-stopped
+    networks:
+      racetime-network:
+        aliases:
+          - racetime.redis
+
+networks:
+  racetime-network:
+
+volumes:
+  mysql-data:

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+
+echo "==> Installing Python dependencies..."
+pip install --user -r requirements.txt
+
+echo "==> Installing Node.js dependencies..."
+npm install
+
+echo "==> Waiting for MySQL to be ready..."
+sleep 10
+
+echo "==> Running database migrations..."
+python manage.py migrate
+
+echo "==> Loading fixtures (if database is empty)..."
+if python manage.py fixtures 2>&1 | grep -q "Duplicate entry"; then
+    echo "    Fixtures already loaded, skipping..."
+else
+    echo "    Fixtures loaded successfully!"
+fi

--- a/.devcontainer/post-start.sh
+++ b/.devcontainer/post-start.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# postStartCommand - runs every time the container starts
+
+# fix git permissions
+git config --global --add safe.directory ${PWD}
+
+# racebot
+echo "==> Starting racebot..."
+nohup python manage.py racebot --noreload > /tmp/racebot.log 2>&1 &
+echo $! > /tmp/racebot.pid
+
+# django
+echo "==> Starting web server..."
+nohup python manage.py runserver 0.0.0.0:8000 > /tmp/runserver.log 2>&1 &
+echo $! > /tmp/runserver.pid
+
+sleep 2


### PR DESCRIPTION
I was setting up a local environment to add some unit tests and ran into some setup friction (Python minor version mismatches, mysqlclient build dependencies, etc.)

This PR adds an optional devcontainer that pins Python and system dependencies in a reproducible way. It does not change CI or existing local workflows. The devcontainer lives entirely under the `/.devcontainer` folder and has no impact on existing setups, fully opt-in

I found this useful because:
- it makes first-time setup more predictable
- it enables options for quick inspection, small changes, or PR review via GitHub Codespaces without local setup
