### PR TITLE
Prevent account deletion before recordable races are finalized (Option 1 of 2)

### DIFF
--- a/racetime/models/user.py
+++ b/racetime/models/user.py
@@ -272,6 +272,17 @@ class User(AbstractBaseUser, PermissionsMixin):
         except self.entrant_set.model.DoesNotExist:
             return None
 
+    @cached_property
+    def pending_recordable_race_entrant(self):
+        """
+        Returns an Entrant object for a race that still needs this user to
+        remain attached so the result can be recorded.
+        """
+        return self.entrant_set.filter(
+            race__recordable=True,
+            race__recorded=False,
+        ).order_by('race__opened_at').first()
+
     @property
     def can_show_profile(self):
         """

--- a/racetime/utils.py
+++ b/racetime/utils.py
@@ -629,8 +629,8 @@ def chunkify(items, size=100):
 def delete_user(request, user, protect=True):
     if protect and (user.is_system or user.is_superuser or user.is_staff):
         raise Exception('Cannot delete protected user.')
-    if user.active_race_entrant:
-        raise Exception('User is currently racing.')
+    if user.pending_recordable_race_entrant:
+        raise Exception('User is entered in a race that has not been recorded yet.')
 
     user_email = user.email
     email_context = {

--- a/racetime/views/user.py
+++ b/racetime/views/user.py
@@ -238,8 +238,12 @@ class DeleteAccount(LoginRequiredMixin, UserMixin, generic.TemplateView):
     template_name = 'racetime/user/delete_account.html'
 
     def post(self, request, *args, **kwargs):
-        if self.user.active_race_entrant:
-            messages.error(request, 'We are unable to delete your account while you are participating in a race.')
+        if self.user.pending_recordable_race_entrant:
+            messages.error(
+                request,
+                'We are unable to delete your account while you are entered '
+                'in a race that has not been recorded yet.'
+            )
             return http.HttpResponseRedirect(reverse('edit_account'))
 
         user = self.user


### PR DESCRIPTION
Summary
- Prevent account deletion while a user is entered in a recordable race that has not been recorded yet.
- Keep deletion allowed for non-recordable fun/custom races.
- Apply the guard in both the account deletion view and shared `delete_user()` utility.

Testing
- `python manage.py check`
- `python manage.py test racetime` *(0 tests found)*
- `python -m py_compile racetime/models/user.py racetime/views/user.py racetime/utils.py`