### PR TITLE
Ignore deleted entrants when recording races (Option 2 of 2)

### DIFF
--- a/racetime/models/race.py
+++ b/racetime/models/race.py
@@ -1358,11 +1358,6 @@ class Race(models.Model):
         if self.hold:
             raise SafeException('Race cannot be finalized, it is on hold.')
         if self.recordable and not self.recorded:
-            if not all([entrant.user_id for entrant in self.entrant_set.all()]):
-                raise SafeException(
-                    'This race cannot be recorded because one or more entrants have '
-                    'deleted their account. Please set this race to "Do not record".'
-                )
             self.recorded = True
             self.recorded_by = recorded_by
             self.unlisted = False

--- a/racetime/models/race.py
+++ b/racetime/models/race.py
@@ -1358,6 +1358,17 @@ class Race(models.Model):
         if self.hold:
             raise SafeException('Race cannot be finalized, it is on hold.')
         if self.recordable and not self.recorded:
+            has_deleted_entrants = self.entrant_set.filter(user__isnull=True).exists()
+            if has_deleted_entrants and self.team_race:
+                raise SafeException(
+                    'This race cannot be recorded because one or more entrants have '
+                    'deleted their account. Please set this race to "Do not record".'
+                )
+            if self.entrant_set.filter(user__isnull=False).count() < 2:
+                raise SafeException(
+                    'This race cannot be recorded because fewer than two entrants '
+                    'still have accounts. Please set this race to "Do not record".'
+                )
             self.recorded = True
             self.recorded_by = recorded_by
             self.unlisted = False

--- a/racetime/rating.py
+++ b/racetime/rating.py
@@ -65,11 +65,14 @@ def _sort_key(group):
 
 
 def rate_race(race):
-    entrants = race.ordered_entrants
+    entrants = race.ordered_entrants.filter(user__isnull=False)
     users = [
         UserRating(entrant, race)
         for entrant in entrants
     ]
+    if not users:
+        return
+
     if not race.team_race:
         groups = [(user,) for user in users]
     else:


### PR DESCRIPTION
Summary
- Allow race recording even when one or more entrants have deleted their account.
- Exclude deleted entrants from the rating calculation so `rate_race()` does not dereference a null user.
- Return early if no remaining entrants can be rated.

Testing
- `python manage.py check`
- `python manage.py test racetime` *(0 tests found)*
- `python -m py_compile racetime/models/race.py racetime/rating.py`

Note
This changes scoring behavior: deleted entrants are ignored for rating purposes, so points are calculated from the remaining users.

Commit 2; Updated to keep the deleted-user guard for team races, since ignoring a deleted entrant there could imbalance teams and skew ratings.

Also added a check so non-team races are only recorded if at least two entrants with accounts remain after deleted users are ignored.