### PR TITLE
Add isort config and sort imports

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,9 @@
+[settings]
+multi_line_output = 3
+include_trailing_comma = true
+force_grid_wrap = 0
+use_parentheses = true
+ensure_newline_before_comments = true
+line_length = 88
+skip_glob = */migrations/*
+skip = racetime/views/__init__.py

--- a/project/asgi.py
+++ b/project/asgi.py
@@ -2,6 +2,7 @@ import os
 
 from channels.routing import ProtocolTypeRouter, URLRouter
 from django.core.asgi import get_asgi_application
+
 from racetime.routing import MiddlewareStack, urlpatterns
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'project.settings')

--- a/project/settings/base.py
+++ b/project/settings/base.py
@@ -2,8 +2,8 @@
 Quick-start development settings - unsuitable for production
 See https://docs.djangoproject.com/en/2.2/howto/deployment/checklist/
 """
-from datetime import datetime
 import os
+from datetime import datetime
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 SECRET_KEY = '00aqmqedb05688z06d_%m%a==yu10am82ff)rcxk4il6@6%2=$'

--- a/racetime/admin/__init__.py
+++ b/racetime/admin/__init__.py
@@ -7,8 +7,8 @@ from django.urls import reverse, set_urlconf
 from django.utils.safestring import mark_safe
 from django_admin_listfilter_dropdown.filters import RelatedDropdownFilter
 
-from . import forms, options
 from .. import models
+from . import forms, options
 
 
 class BanAdmin(options.ModelAdmin):

--- a/racetime/apps.py
+++ b/racetime/apps.py
@@ -1,7 +1,9 @@
-from django.apps import AppConfig as BaseAppConfig, apps
+from urllib.parse import quote
+
+from django.apps import AppConfig as BaseAppConfig
+from django.apps import apps
 from django.conf import settings
 from django.utils import timezone
-from urllib.parse import quote
 
 
 class AppConfig(BaseAppConfig):

--- a/racetime/consumers.py
+++ b/racetime/consumers.py
@@ -9,8 +9,14 @@ from oauth2_provider.settings import oauth2_settings
 from websockets import ConnectionClosed
 
 from . import race_actions, race_bot_actions
-from .models import Bot, Category, Race, Message
-from .utils import SafeException, exception_to_msglist, get_chat_history, get_hashids, get_action_button
+from .models import Bot, Category, Message, Race
+from .utils import (
+    SafeException,
+    exception_to_msglist,
+    get_action_button,
+    get_chat_history,
+    get_hashids,
+)
 
 
 class OAuthConsumerMixin:

--- a/racetime/forms.py
+++ b/racetime/forms.py
@@ -3,8 +3,6 @@ from copy import deepcopy
 from datetime import timedelta
 
 from bs4 import BeautifulSoup
-from django_recaptcha.fields import ReCaptchaField
-from django_recaptcha.widgets import ReCaptchaV2Checkbox
 from django import forms
 from django.contrib.auth import forms as auth_forms
 from django.core import validators
@@ -17,6 +15,8 @@ from django.http import Http404
 from django.template.loader import render_to_string
 from django.urls import reverse_lazy
 from django.utils.html import format_html
+from django_recaptcha.fields import ReCaptchaField
+from django_recaptcha.widgets import ReCaptchaV2Checkbox
 
 from . import models
 

--- a/racetime/management/commands/get_pw_reset.py
+++ b/racetime/management/commands/get_pw_reset.py
@@ -1,9 +1,9 @@
 from django.conf import settings
+from django.contrib.auth.tokens import default_token_generator
+from django.core.management import BaseCommand
 from django.urls import reverse
 from django.utils.encoding import force_bytes
 from django.utils.http import urlsafe_base64_encode
-from django.contrib.auth.tokens import default_token_generator
-from django.core.management import BaseCommand
 
 from ...models import User
 

--- a/racetime/management/commands/twitch_update.py
+++ b/racetime/management/commands/twitch_update.py
@@ -2,9 +2,9 @@ import requests
 from django.conf import settings
 from django.core.management import BaseCommand
 
-from . import TalksToTwitch
 from ...models import User
 from ...utils import chunkify
+from . import TalksToTwitch
 
 
 class Command(BaseCommand, TalksToTwitch):

--- a/racetime/management/commands/user_data_attrition.py
+++ b/racetime/management/commands/user_data_attrition.py
@@ -5,6 +5,7 @@ from django.utils import timezone
 
 from ...models import UserAction
 
+
 class Command(BaseCommand):
     help = 'Clear out user data that too old to be relevant.'
     retention_period = timedelta(days=366*5)

--- a/racetime/models/__init__.py
+++ b/racetime/models/__init__.py
@@ -5,13 +5,7 @@ from .chat import Message
 from .choices import EntrantStates, RaceStates
 from .race import Entrant, Race
 from .team import Team, TeamAuditLog, TeamMember
-from .user import (
-    Ban,
-    User,
-    UserAction,
-    UserLog,
-    UserRanking,
-)
+from .user import Ban, User, UserAction, UserLog, UserRanking
 
 __all__ = [
     # admin

--- a/racetime/models/category.py
+++ b/racetime/models/category.py
@@ -16,8 +16,8 @@ from django.utils.safestring import mark_safe
 
 from racetime.models.abstract import AbstractAuditLog
 
-from .choices import RaceStates
 from ..utils import SafeException, generate_race_slug, get_hashids
+from .choices import RaceStates
 
 
 class Category(models.Model):

--- a/racetime/models/race.py
+++ b/racetime/models/race.py
@@ -21,12 +21,18 @@ from django.utils.safestring import mark_safe
 from django.utils.text import slugify
 from trueskill import Rating, TrueSkill, quality_1vs1
 
-from .choices import EntrantStates, RaceStates
 from ..rating import rate_race
 from ..utils import (
-    SafeException, ShieldedUser, SyncError, generate_team_name,
-    get_action_button, get_chat_history, timer_html, timer_str,
+    SafeException,
+    ShieldedUser,
+    SyncError,
+    generate_team_name,
+    get_action_button,
+    get_chat_history,
+    timer_html,
+    timer_str,
 )
+from .choices import EntrantStates, RaceStates
 
 
 class Race(models.Model):

--- a/racetime/models/team.py
+++ b/racetime/models/team.py
@@ -9,9 +9,9 @@ from django.urls import reverse
 from django.utils.functional import cached_property
 from django.utils.text import slugify
 
-from .abstract import AbstractAuditLog
 from ..utils import generate_team_name
 from ..validators import UsernameValidator
+from .abstract import AbstractAuditLog
 
 
 class Team(models.Model):

--- a/racetime/models/user.py
+++ b/racetime/models/user.py
@@ -10,9 +10,9 @@ from django.utils import timezone
 from django.utils.functional import cached_property
 from django.utils.text import slugify
 
-from .choices import EntrantStates, RaceStates
 from ..utils import determine_ip, get_hashids, timer_html
 from ..validators import UsernameValidator
+from .choices import EntrantStates, RaceStates
 
 
 class UserManager(BaseUserManager):

--- a/racetime/race_bot_actions.py
+++ b/racetime/race_bot_actions.py
@@ -5,6 +5,7 @@ from django.db.models import F
 
 from racetime import forms, models
 from racetime.utils import SafeException, get_hashids
+
 from .race_actions import Message
 
 

--- a/racetime/urls.py
+++ b/racetime/urls.py
@@ -1,4 +1,4 @@
-from django.urls import path, include
+from django.urls import include, path
 from oauth2_provider import views as oauth2_views
 
 from . import views

--- a/racetime/utils.py
+++ b/racetime/utils.py
@@ -1,5 +1,5 @@
-import datetime
 import colorsys
+import datetime
 import json
 import random
 from collections import OrderedDict
@@ -7,7 +7,8 @@ from urllib.parse import urlencode
 
 import requests
 from channels_redis.core import RedisChannelLayer as BaseRedisChannelLayer
-from channels_redis.serializers import JSONSerializer as BaseJSONSerializer, registry
+from channels_redis.serializers import JSONSerializer as BaseJSONSerializer
+from channels_redis.serializers import registry
 from django.apps import apps
 from django.conf import settings
 from django.core.mail import send_mail

--- a/racetime/views/bot.py
+++ b/racetime/views/bot.py
@@ -9,9 +9,9 @@ from django.utils.functional import cached_property
 from django.views import generic
 from oauth2_provider.models import get_application_model
 
-from .base import UserMixin
 from .. import forms, models
 from ..utils import get_hashids
+from .base import UserMixin
 
 
 class BotPageMixin(UserPassesTestMixin, UserMixin):

--- a/racetime/views/category.py
+++ b/racetime/views/category.py
@@ -3,12 +3,12 @@ import json
 from django import http
 from django.conf import settings
 from django.contrib import messages
-from django.contrib.auth.mixins import UserPassesTestMixin, LoginRequiredMixin
+from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
 from django.contrib.humanize.templatetags.humanize import ordinal
 from django.core.cache import cache
 from django.core.exceptions import PermissionDenied
 from django.core.mail import send_mail
-from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
+from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db import models as db_models
 from django.db.transaction import atomic
@@ -21,8 +21,8 @@ from django.utils.text import slugify
 from django.views import generic
 from oauth2_provider.views import ScopedProtectedResourceView
 
-from .base import BotMixin, PublicAPIMixin, UserMixin
 from .. import forms, models
+from .base import BotMixin, PublicAPIMixin, UserMixin
 
 
 class Category(UserMixin, generic.DetailView):

--- a/racetime/views/goal.py
+++ b/racetime/views/goal.py
@@ -9,9 +9,9 @@ from django.urls import reverse
 from django.utils.functional import cached_property
 from django.views import generic
 
-from .base import UserMixin
 from .. import forms, models
 from ..utils import get_hashids
+from .base import UserMixin
 
 
 class GoalPageMixin(UserPassesTestMixin, UserMixin):

--- a/racetime/views/home.py
+++ b/racetime/views/home.py
@@ -4,8 +4,8 @@ from django.db.models import Count, Q
 from django.utils.functional import cached_property
 from django.views import generic
 
-from .base import UserMixin
 from ..models import Category, Entrant, RaceStates
+from .base import UserMixin
 
 
 class Home(UserMixin, generic.TemplateView):

--- a/racetime/views/race.py
+++ b/racetime/views/race.py
@@ -5,8 +5,8 @@ from asgiref.sync import async_to_sync
 from channels.layers import get_channel_layer
 from django import http
 from django.conf import settings
-from django.contrib.auth.mixins import UserPassesTestMixin
 from django.contrib.auth.decorators import login_required
+from django.contrib.auth.mixins import UserPassesTestMixin
 from django.core.cache import cache
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db.models import F, Q
@@ -21,9 +21,15 @@ from django.views.decorators.csrf import csrf_exempt
 from django.views.generic.detail import SingleObjectMixin
 from oauth2_provider.views import ScopedProtectedResourceView
 
-from .base import BotMixin, CanModerateRaceMixin, CanMonitorRaceMixin, PublicAPIMixin, UserMixin
 from .. import forms, models
 from ..utils import get_action_button, get_hashids, twitch_auth_url
+from .base import (
+    BotMixin,
+    CanModerateRaceMixin,
+    CanMonitorRaceMixin,
+    PublicAPIMixin,
+    UserMixin,
+)
 
 
 class RaceMixin(SingleObjectMixin):

--- a/racetime/views/race_actions.py
+++ b/racetime/views/race_actions.py
@@ -1,7 +1,7 @@
 from django.contrib.auth.mixins import LoginRequiredMixin
 
-from .base import BaseRaceAction
 from .. import race_actions
+from .base import BaseRaceAction
 
 
 class RaceAction(LoginRequiredMixin, BaseRaceAction):

--- a/racetime/views/race_monitor_actions.py
+++ b/racetime/views/race_monitor_actions.py
@@ -1,10 +1,10 @@
 from django.http import Http404
 from django.views import generic
 
-from .base import BaseRaceAction, CanModerateRaceMixin, CanMonitorRaceMixin
 from ..forms import InviteForm
 from ..models import Entrant, User
 from ..utils import SafeException
+from .base import BaseRaceAction, CanModerateRaceMixin, CanMonitorRaceMixin
 
 
 class EntrantAction(BaseRaceAction):

--- a/racetime/views/team.py
+++ b/racetime/views/team.py
@@ -13,8 +13,8 @@ from django.utils.functional import cached_property
 from django.utils.text import slugify
 from django.views import generic
 
-from .base import PublicAPIMixin, UserMixin
 from .. import forms, models
+from .base import PublicAPIMixin, UserMixin
 
 
 class Team(UserMixin, generic.DetailView):

--- a/racetime/views/user.py
+++ b/racetime/views/user.py
@@ -6,11 +6,11 @@ from django.contrib.auth import login, logout, update_session_auth_hash
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.core.exceptions import PermissionDenied
 from django.core.mail import send_mail
-from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
+from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from django.db.models import Count, Q
 from django.db.transaction import atomic
 from django.forms import model_to_dict
-from django.shortcuts import resolve_url, get_object_or_404
+from django.shortcuts import get_object_or_404, resolve_url
 from django.template.loader import render_to_string
 from django.urls import reverse, reverse_lazy
 from django.utils import timezone
@@ -22,10 +22,16 @@ from django.views.decorators.debug import sensitive_post_parameters
 from oauth2_provider.models import get_access_token_model, get_application_model
 from oauth2_provider.views import AuthorizationView, ProtectedResourceView
 
-from .base import PublicAPIMixin, UserMixin
 from .. import forms, models
 from ..middleware import CsrfViewMiddlewareTwitch
-from ..utils import delete_user, notice_exception, patreon_auth_url, patreon_update_memberships, twitch_auth_url
+from ..utils import (
+    delete_user,
+    notice_exception,
+    patreon_auth_url,
+    patreon_update_memberships,
+    twitch_auth_url,
+)
+from .base import PublicAPIMixin, UserMixin
 
 
 class ViewProfile(UserMixin, generic.DetailView):

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 from setuptools import find_packages, setup
 
-
 setup(
     name='racetime',
     install_requires=[


### PR DESCRIPTION
## What this is

Adds [isort](https://pycqa.github.io/isort/), a tool that keeps `import` statements in a consistent order; plus a one-time pass applying it across the codebase.

## Why bother

Right now import order is freeform, so it drifts. In practice that costs us three small-but-recurring things:

- **Review noise**: PRs that add an import often reshuffle nearby lines, and reviewers can't tell the real change from the churn. I hit this while cleaning up #231, which is what prompted this PR.
- **Merge conflicts**: two branches adding imports to the same file collide for no good reason.
- **Bikeshedding**: a tool answers where the import lives in the file, so nobody has to think about it.

None of these are on fire. This is a papercut fix.

## What it does *not* change

- **Zero functional changes.** It only reorders/wraps import lines. Every changed file still compiles and behaves identically.
- **It matches the style already dominant in the repo** (single-line imports, wrapping long ones vertically). I didn't impose a new aesthetic. I measured what the codebase already does and configured isort to preserve it. I have no strong opinions about any of the settings, and am happy to set them to whatever you'd prefer if different.
- **Generated migrations are skipped**, so Django's output is left alone.
- **`racetime/views/__init__.py` is skipped**: its imports are deliberately hand-ordered to pair each view with its OAuth variant (`RaceChatPin` next to `OAuthRaceChatPin`). The config respects that instead of flattening it, since we can't auto-sort while preserving that intent.

## How it's structured

Two commits, so you can review the decision separately from the churn:

1. **`Add isort configuration`**: just `.isort.cfg` (~9 lines). This is the only part that's a *decision*; read this one.
2. **`Sort imports with isort`**: the mechanical result of running the tool. 27 files, all reordering. You can skim or trust it; it's reproducible by running `isort .`.

## What you have to do going forward

Nothing required. If you ever want to keep it tidy, `pip install isort && isort .` reformats everything; running it twice is a no-op. If you decide you hate it, deleting `.isort.cfg` reverts to freeform with no other cleanup.

## If you love it and want it enforced automatically

Happy to follow up with a CI check (`isort --check`) and/or a pre-commit hook so it stays consistent without anyone thinking about it. if you'd prefer