### PR TITLE
Fix WebSocket Connection Issues

### DIFF
--- a/project/settings/base.py
+++ b/project/settings/base.py
@@ -76,7 +76,10 @@ CHANNEL_LAYERS = {
     'default': {
         'BACKEND': 'racetime.utils.RedisChannelLayer',
         'CONFIG': {
-            "hosts": [('racetime.redis', 6379)],
+            "hosts": [{
+                'address': 'redis://racetime.redis:6379',
+                'socket_timeout': None
+            }],
         },
     },
 }


### PR DESCRIPTION
Fixes #241 

Currently, all environments that have redis-py v8.x.x+ installed will suffer from #241. (`docker-compose exec racetime.web pip show redis`). **This will be the case for all new environments that are created from scratch following the README**

<ins>**How this Happens:**</ins> When launching a new environment, dependencies listed within `requirements.txt` are installed within the container. We require any version within the range 4.0-5.0 for the `channels_redis` package but `channels_redis` also depends on `redis-py` . Since we don't specify a specific version for `redis-py`, the latest version available is installed (at the moment should be `8.1.0`).

<ins>**The Culprit:**</ins> As of `redis-py v8.0.0` the default values of `socket_timeout` and `socket_connect_timeout` have been changed from `None` to `5` seconds.

<ins>**How this conflicts with Django Channels:**</ins> The 5 second `socket_timeout` is being met before `BZPOPMIN` (similar to `BLPOP`) operates causing the WebSocket connection to be destroyed.

This change overrides the `socket_timeout` in the channel layer to restore previous behavior. After applying the fix, `docker-compose down` then `docker-compose up --build -d` to rebuild the image

**redis-py 8.0.0 Release Notes:** https://github.com/redis/redis-py/releases#release-v8.0.0
